### PR TITLE
Fix not to use `server` command

### DIFF
--- a/solargraph_utils/core.py
+++ b/solargraph_utils/core.py
@@ -26,7 +26,7 @@ class Server:
     def start(self):
         env = os.environ.copy()
         self.proc = subprocess.Popen(
-            [self.command, 'server', *self.args],
+            [self.command, 'socket', *self.args],
             env=env,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
## My environment:

```
$ ruby --version
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]

$ solargraph -v
0.21.0

$ pip show solargraph-utils.py
Name: solargraph-utils.py
Version: 1.0.0
Summary: solargraph-utils for python
Home-page: https://github.com/uplus/solargraph-utils.py
Author: uplus
Author-email: UNKNOWN
License: The MIT License (MIT)
Location: /Users/furuhama.yusuke/.local/lib/python3.6/site-packages
Requires:
Required-by:
```
and `deoplete-solargraph` plugin is up-to-date.

## Problem:

```
[deoplete] Traceback (most recent call last):
  File "/Users/furuhama.yusuke/.local/share/dein/repos/github.com/uplus/deoplete-solargraph/rplugin/python3/deoplete/source/solargraph.py", line 56, in start_server
    self.server = solar.Server()
  File "/Users/furuhama.yusuke/.local/lib/python3.6/site-packages/solargraph_utils/core.py", line 19, in __init__
    self.start()
  File "/Users/furuhama.yusuke/.local/lib/python3.6/site-packages/solargraph_utils/core.py", line 40, in start
    raise ServerError('Failed to start server' + (output and ':\n' + output))
solargraph_utils.helpers.ServerError: Failed to start server:
Could not find command "server".
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/furuhama.yusuke/.local/share/dein/.cache/init.vim/.dein/rplugin/python3/deoplete/child.py", line 229, in _gather_results
    ctx['candidates'] = source.gather_candidates(ctx)
  File "/Users/furuhama.yusuke/.local/share/dein/repos/github.com/uplus/deoplete-solargraph/rplugin/python3/deoplete/source/solargraph.py", line 70, in gather_candidates
    if not self.start_server():
  File "/Users/furuhama.yusuke/.local/share/dein/repos/github.com/uplus/deoplete-solargraph/rplugin/python3/deoplete/source/solargraph.py", line 57, in start_server
    except solar.ServerError as error:
AttributeError: module 'solargraph_utils' has no attribute 'ServerError'
Error from solargraph: AttributeError("module 'solargraph_utils' has no attribute 'ServerError'",).  Use :messages / see above for error details.
```

## How to solve:

By ver 0.21.0, solargraph just serve `socket` command, instead of using `server` command.
Therefore, I fixed script to use `socket` command.